### PR TITLE
Fix: APIリクエストのパスを本番環境用に修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,15 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
     const generateBtn = document.getElementById('generate-btn');
     const fairyCard = document.getElementById('fairy-card');
-    const serverUrl = 'http://127.0.0.1:8000'; // Define server URL for local development
 
     generateBtn.addEventListener('click', async () => {
         fairyCard.classList.add('hidden');
         // Optional: Add a loading spinner here
 
         try {
-            // Fetch fairy text from backend
-            const textResponse = await fetch(`${serverUrl}/generate_fairy_text`, {
+            // Fetch fairy text from backend using a relative path for production
+            const textResponse = await fetch('/generate_fairy_text', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -39,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // Generate image (using the generated fairy name for the prompt)
             const imagePrompt = `A melancholic swamp fairy named ${fairyData.name || 'Mysterious Fairy'} stands beside a misty marsh under twilight. The atmosphere is eerie and dreamy, with whimsical, surreal, gothic, and antique elements, in the style of Mark Ryden. Lighting is soft and sepia-toned, evoking a mysterious fairy tale.`;
-            const imageResponse = await fetch(`${serverUrl}/generate_image`, {
+            const imageResponse = await fetch('/generate_image', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION

   1 Renderでのデプロイ後、APIへの接続に失敗する問題を修正しまし
     た。
   2 
   3 - **修正内容:**
   4   - `script.js`
     内のAPIリクエストURLを、ローカル開発用の絶対パス (
     `http://127.0.0.1:8000`) から、本番環境で動作する相対パス (
     `/generate_fairy_text`) に変更しました。
   5 
   6 これで、デプロイされたアプリケーションが自身のサーバーと正し
     く通信できるようになります。